### PR TITLE
Fixed title of ECE3030

### DIFF
--- a/_posts/2025-04-28-ece3030.md
+++ b/_posts/2025-04-28-ece3030.md
@@ -1,6 +1,6 @@
 ---
 layout: class
-title: "Digital Logic and Computer Organization"
+title: "Electromagnetic Fields and Waves"
 code: "ECE 3030"
 categories: [3000]
 permalink: /classes/3000/ece3030/


### PR DESCRIPTION
Changed from "Digital Logic and Computer Organization" to the correct title: "Electromagnetic Fields and Waves"